### PR TITLE
Fixes view error for Press and People exhibit.

### DIFF
--- a/app/controllers/exhibits_controller.rb
+++ b/app/controllers/exhibits_controller.rb
@@ -32,6 +32,7 @@ class ExhibitsController < ApplicationController
   end
 
   def press_and_people
+    @full_program_video_links = ExhibitsData::PressAndPeople.full_program_video_links
   end
 
   def from_the_vault

--- a/app/views/exhibits/press_and_people.html.erb
+++ b/app/views/exhibits/press_and_people.html.erb
@@ -1,13 +1,13 @@
 <div class='override'>
-  <%= render layout: 'override/partials/header', 
+  <%= render layout: 'exhibits/header', 
              locals: { title: 'Press and the People', wp_img: '2014/10/Exhibit_Press_People.jpg' } do %>
     <p>Groundbreaking in concept, Press and the People was one of the first series to explore how newspaper and television reporters covered key events in the 1950s, and how that shaped public opinion and knowledge on issues such as the nuclear weapons, the Berlin Crisis and secrecy in the government. Hosted by Louis Lyons, the first television newscaster at WGBH, Press and the People brought together esteemed journalists such as Edward R. Murrow, Eric Sevareid and Martin Agronsky to discuss their role in the creation and dissemination of current events.</p>
   <% end %>
 
   <% cache('prpe-press-and-the-people-tabs') do %>
     <%= render partial: 'global_partials/tabs', locals: { 
-      tabs: 
-        [{title: "Full Program Video", content: render(partial: 'exhibits/press_and_people/videos')}]
+      tabs:
+        [{title: "Full Program Video", content: render(partial: 'global_partials/multicolumn_links_list', locals: {links: @full_program_video_links, num_cols: 1})}]
     } %> 
   <% end %>
     

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,8 @@ Openvault::Application.routes.draw do
 
   get 'catalog/prpe-press-and-the-people', to: 'exhibits#press_and_people'
   get 'collections/prpe-press-and-the-people', to: 'exhibits#press_and_people'
+  get 'catalog/press-and-people', to: 'exhibits#press_and_people'
+  get 'collections/press-and-people', to: 'exhibits#press_and_people'
 
   get 'catalog/march-march-on-washington', to: 'exhibits#march_on_washington'
   get 'collections/march-march-on-washington', to: 'exhibits#march_on_washington'

--- a/spec/routing/exhibits_routing_spec.rb
+++ b/spec/routing/exhibits_routing_spec.rb
@@ -13,6 +13,8 @@ describe "routing for exhibits" do
     'collections/vietnam-the-vietnam-collection'  => {controller: 'exhibits', action: 'vietnam'},
     'catalog/prpe-press-and-the-people'  => {controller: 'exhibits', action: 'press_and_people'},
     'collections/prpe-press-and-the-people'  => {controller: 'exhibits', action: 'press_and_people'},
+    'catalog/press-and-people'  => {controller: 'exhibits', action: 'press_and_people'},
+    'collections/press-and-people'  => {controller: 'exhibits', action: 'press_and_people'},
     'catalog/march-march-on-washington'  => {controller: 'exhibits', action: 'march_on_washington'},
     'collections/march-march-on-washington'  => {controller: 'exhibits', action: 'march_on_washington'},
     'catalog/sbro-say-brother'  => {controller: 'exhibits', action: 'say_brother'},


### PR DESCRIPTION
Adds ExhibitsData::PressAndPeople module with #full_program_video_links method to return data, and uses that in ExhibitsController and related views.
Adds routes for collections/press-and-people and catalog/press-and-people.